### PR TITLE
Redirect dangerous_eval to correct page

### DIFF
--- a/source/docs/warning_types/dangerous_eval/index.markdown
+++ b/source/docs/warning_types/dangerous_eval/index.markdown
@@ -1,0 +1,13 @@
+---
+layout: page
+title: "Dangerous Evaluation"
+date: 2011-11-10 12:47
+comments: false
+sharing: true
+footer: true
+---
+
+User input in an `eval` statement is VERY dangerous, so this will always raise a warning. Brakeman looks for calls to `eval`, `instance_eval`, `class_eval`, and `module_eval`.
+
+---
+Back to [Warning Types](/docs/warning_types)

--- a/source/docs/warning_types/dangerous_evaluation/index.markdown
+++ b/source/docs/warning_types/dangerous_evaluation/index.markdown
@@ -7,8 +7,8 @@ sharing: true
 footer: true
 ---
 
-User input in an `eval` statement is VERY dangerous, so this will always raise a warning. Brakeman looks for calls to `eval`, `instance_eval`, `class_eval`, and `module_eval`.
+<script>
+window.location.replace("http://brakemanscanner.org/docs/warning_types/dangerous_eval/");
+</script>
 
----
-Back to [Warning Types](/docs/warning_types)
-
+Content moved to [Dangerous Eval](dangerous_eval/).

--- a/source/docs/warning_types/evaluation/index.markdown
+++ b/source/docs/warning_types/evaluation/index.markdown
@@ -8,7 +8,7 @@ footer: true
 ---
 
 <script>
-window.location.replace("http://brakemanscanner.org/docs/warning_types/dangerous_evaluation/");
+window.location.replace("http://brakemanscanner.org/docs/warning_types/dangerous_eval/");
 </script>
 
-Content moved to [Dangerous Evaluation](dangerous_evaluation/).
+Content moved to [Dangerous Eval](dangerous_eval/).


### PR DESCRIPTION
This adds a redirect for:

http://brakemanscanner.org/docs/warning_types/dangerous_eval

to:

http://brakemanscanner.org/docs/warning_types/dangerous_evaluation/

This is necessary because the brakeman gem points to this url as the
link for the dangerous eval rule.