### PR TITLE
Add Rake task to create pages from Brakeman docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 _gist_cache
 _code_cache
 _deploy
+_work
 public
 sass.old
 source.old


### PR DESCRIPTION
The warning type documentation has been moved from this repository to
the Brakeman gem for use in Brakeman's output with certain report
formats. This task will synchronize the contents of the Brakeman docs
directory with pages in the source directory and add the appropriate
Jekyll header and navigation footer. Page files will only be written if
a corresponding file in brakeman is added or has its contents changed.