### PR TITLE
Replace broken 2010 OWASP Top Ten links with archive.org versions

### DIFF
--- a/source/docs/warning_types/command_injection/index.markdown
+++ b/source/docs/warning_types/command_injection/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Injection is #1 on the 2010 [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A1) web security risks. Command injection occurs when shell commands unsafely include user-manipulatable values.
+Injection is #1 on the 2010 [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A1) web security risks. Command injection occurs when shell commands unsafely include user-manipulatable values.
 
 There are many ways to run commands in Ruby:
 

--- a/source/docs/warning_types/content_tag/index.markdown
+++ b/source/docs/warning_types/content_tag/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere. XSS occurs when a user-manipulatable value is displayed on a web page without escaping it, allowing someone to inject Javascript or HTML into the page.
+Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere. XSS occurs when a user-manipulatable value is displayed on a web page without escaping it, allowing someone to inject Javascript or HTML into the page.
 
 [content\_tag](http://apidock.com/rails/ActionView/Helpers/TagHelper/content_tag) is a view helper which generates an HTML tag with some content:
 

--- a/source/docs/warning_types/cross-site_request_forgery/index.markdown
+++ b/source/docs/warning_types/cross-site_request_forgery/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Cross-site request forgery is #5 on the [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A5). CSRF allows an attacker to perform actions on a website as if they are an authenticated user.
+Cross-site request forgery is #5 on the [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A5). CSRF allows an attacker to perform actions on a website as if they are an authenticated user.
 
 This warning is raised when no call to `protect_from_forgery` is found in `ApplicationController`. This method prevents CSRF.
 

--- a/source/docs/warning_types/cross_site_scripting/index.markdown
+++ b/source/docs/warning_types/cross_site_scripting/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere.
+Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere.
 
 XSS occurs when a user-manipulatable value is displayed on a web page without escaping it, allowing someone to inject Javascript or HTML into the page.
 

--- a/source/docs/warning_types/cross_site_scripting_to_json/index.markdown
+++ b/source/docs/warning_types/cross_site_scripting_to_json/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere.
+Cross site scripting (or XSS) is #2 on the 2010 [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A2) web security risks and it pops up nearly everywhere.
 
 XSS occurs when a user-manipulatable value is displayed on a web page without escaping it, allowing someone to inject Javascript or HTML into the page.  Calls to `Hash#to_json` can be used to trigger XSS.  Brakeman will check to see if there are any calls to `Hash#to_json` with `ActiveSupport#escape_html_entities_in_json` set to false (or if you are running Rails < 2.1.0 which did not have this functionality).
 

--- a/source/docs/warning_types/redirect/index.markdown
+++ b/source/docs/warning_types/redirect/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Unvalidated redirects and forwards are #10 on the [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A10).
+Unvalidated redirects and forwards are #10 on the [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A10).
 
 Redirects which rely on user-supplied values can be used to "spoof" websites or hide malicious links in otherwise harmless-looking URLs. They can also allow access to restricted areas of a site if the destination is not validated.
 

--- a/source/docs/warning_types/sql_injection/index.markdown
+++ b/source/docs/warning_types/sql_injection/index.markdown
@@ -7,7 +7,7 @@ sharing: true
 footer: true
 ---
 
-Injection is #1 on the 2010 [OWASP Top Ten](https://www.owasp.org/index.php/Top_10_2010-A1) web security risks. SQL injection is when a user is able to manipulate a value which is used unsafely inside a SQL query. This can lead to data leaks, data loss, elevation of privilege, and other unpleasant outcomes.
+Injection is #1 on the 2010 [OWASP Top Ten](https://web.archive.org/web/20190223031311/https://www.owasp.org/index.php/Top_10_2010-A1) web security risks. SQL injection is when a user is able to manipulate a value which is used unsafely inside a SQL query. This can lead to data leaks, data loss, elevation of privilege, and other unpleasant outcomes.
 
 Brakeman focuses on ActiveRecord methods dealing with building SQL statements.
 


### PR DESCRIPTION
The 2010 OWASP Top Ten pages are no longer online, so the links in various parts of the Brakeman documentation are broken. There is a [PDF version](https://owasp.org/www-pdf-archive/OWASP_Top_10_-_2010.pdf), but it is not very web friendly.

At some point maybe the docs should be updated to reference something more recent than the 2010 list. The "quick fix" proposed by this PR is to simply update the links to use the archive.org snapshots of the OWASP pages from before they were taken offline.